### PR TITLE
feat: Enhance MuseScore PNG generation debugging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # DBus 관련 (Qt 앱에서 필요할 수 있음)
     dbus-x11 \
     # -----------------------------------------------------
+    && musescore3 --version \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This commit introduces extensive logging and a diagnostic test to help you identify and resolve failures in MuseScore PNG generation.

Key changes:

- Enhanced logging in `app.py`:
    - `generate_music21_score_with_fallback`: Added detailed logging for MusicXML content (both dynamically generated by music21 and for direct MuseScore calls), MuseScore subprocess execution (command, stdout, stderr), and temporary file paths.
    - `setup_music21_environment`: Improved logging for MuseScore path detection, music21 UserSettings configuration, and the MuseScore version check.
- Dockerfile modification:
    - Added `RUN musescore3 --version` to the Docker build process to verify MuseScore installation and log its version.
- Conditional hardcoded MusicXML test:
    - Introduced a `USE_HARDCODED_XML_TEST` flag in `app.py`. When enabled, this bypasses music21's dynamic score generation and attempts to create a PNG from a simple, hardcoded MusicXML string using MuseScore directly. This helps isolate whether issues lie with the MuseScore environment itself or with the dynamically generated scores.

These changes aim to provide comprehensive information in the logs to pinpoint the root cause of PNG generation failures, such as issues with MuseScore installation, Xvfb setup, file permissions, malformed MusicXML, or MuseScore runtime errors.