### PR TITLE
fix: Add missing subprocess import in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ import logging
 import tempfile
 import shutil
 import base64 
+import subprocess
 
 # Music21 라이브러리 (악보 생성)
 try:


### PR DESCRIPTION
Resolves a RuntimeError caused by a NameError when 'subprocess' was not defined in the scope of the `generate_music21_score_with_fallback` function. The `subprocess` module is used for explicit calls to MuseScore for SVG/PNG generation.

This commit adds `import subprocess` to the global import block at the beginning of `app.py` to make it available throughout the module.