### PR TITLE
fix: 악보 자동 생성 시 시드가 고정돼 같은 악보만 나오던 문제

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -660,8 +660,9 @@
                         </div>
 
                         <div class="field">
-                            <label for="seed_input">시드 (비우면 랜덤)</label>
+                            <label for="seed_input">시드 (비우면 매번 랜덤)</label>
                             <input type="number" id="seed_input" name="seed_input" placeholder="예: 12345" min="0" step="1">
+                            <p class="hint" id="lastSeedInfo" style="display:none;"></p>
                         </div>
                     </div>
 
@@ -841,7 +842,8 @@
 
                 if (response.ok && data.status === 'success') {
                     notesSequenceInput.value = data.notes;
-                    if (data.seed != null) document.getElementById('seed_input').value = data.seed;
+                    // 시드는 입력칸에 되쓰지 않는다(비어 있으면 매번 랜덤 유지). 대신 안내로 표시.
+                    if (data.seed != null) showLastSeed(data.seed);
                     showMessage("🎉 악보가 생성되었습니다! 재생하거나 WAV·MP3·MIDI로 내보내세요. (시드 " + data.seed + ")", 'success');
                     renderSheetMusic(data.notes, parseInt(length), parseInt(bpm));
                     updateShareUrl();
@@ -857,6 +859,19 @@
             } finally {
                 setLoadingState('loadingSpinnerNotes', false);
             }
+        }
+
+        // 방금 생성에 쓰인 시드를 안내로 표시. '고정'을 누르면 입력칸에 넣어 재현 가능.
+        function showLastSeed(seed) {
+            const el = document.getElementById('lastSeedInfo');
+            if (!el) return;
+            el.innerHTML = '방금 시드: <code>' + seed + '</code> · <a href="#" onclick="return fixSeed(' + seed + ')">이 시드 고정</a>';
+            el.style.display = 'block';
+        }
+        function fixSeed(seed) {
+            document.getElementById('seed_input').value = seed;
+            showMessage('🔒 시드 ' + seed + ' 고정됨 — 같은 설정이면 동일한 악보가 재현됩니다. (칸을 비우면 다시 랜덤)', 'info');
+            return false;
         }
 
         // ============================================================


### PR DESCRIPTION
## 문제
"악보 자동 생성"을 누르면 이전 시드가 유지되면서 같은 악보가 반복 생성됨.

## 원인
생성 응답의 시드를 시드 입력칸(`seed_input`)에 되써 넣고 있어서, 다음 생성 때 그 시드가 전송돼 동일 악보가 나왔음. → "비우면 랜덤" 동작이 깨짐.

## 수정
- 생성 후 시드를 입력칸에 **되쓰지 않음** → 칸이 비어 있으면 매번 랜덤 유지
- 방금 쓰인 시드는 입력칸 아래 **안내(hint)** 로 표시하고, "이 시드 고정" 링크로 원할 때만 잠금(재현용)
- 라벨 문구 정리("비우면 매번 랜덤")

## 검증 (Playwright)
- 빈 시드로 3회 생성 → 모두 다른 악보, 입력칸은 계속 빈 상태 유지
- "이 시드 고정" 후 2회 생성 → 동일 악보 재현
- 칸 비우기 → 다시 랜덤

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5jACdksKje2ZhNtNuAAUX)_