### PR TITLE
학습 탭 악보/재생부 초컴팩트화 (761px → 230px)

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -677,18 +677,48 @@
 
         /* 학습 탭: 악보 + 재생만 남기고 프리셋·생성 버튼·내보내기 숨김 */
         #bassGeneratorForm[data-tab="learn"] .learn-hide { display: none !important; }
-        /* 학습 탭: 악보 스테이지를 상단 고정(sticky)해 교과서를 스크롤해도 항상 보이게 */
+
+        /* ── 학습 탭: 초컴팩트 악보 바 ──
+           헤더·범례·로마숫자까지 숨기고, 악보는 축소·높이 제한, 재생부는 슬림하게.
+           스테이지 자체 스크롤(overflow)을 없애 중첩 스크롤의 어색함 제거. */
         #bassGeneratorForm[data-tab="learn"] .bl-stage {
-            position: sticky; top: 8px; z-index: 30;
+            position: sticky; top: 6px; z-index: 30;
             background: var(--surface-card);
-            box-shadow: 0 10px 30px rgba(20, 25, 40, 0.14);
-            max-height: calc(100vh - 16px); overflow: auto;
+            box-shadow: 0 8px 24px rgba(20, 25, 40, 0.16);
+            padding: 10px 14px 10px;
+            border-radius: var(--radius-lg);
         }
         [data-theme="dark"] #bassGeneratorForm[data-tab="learn"] .bl-stage {
-            box-shadow: 0 12px 34px rgba(0, 0, 0, 0.6);
+            box-shadow: 0 10px 28px rgba(0, 0, 0, 0.6);
         }
-        /* 학습 탭에선 악보 종이 높이를 제한해 sticky 헤더가 지나치게 커지지 않게 */
-        #bassGeneratorForm[data-tab="learn"] .paper { max-height: 46vh; }
+        #bassGeneratorForm[data-tab="learn"] .bl-stage__head,
+        #bassGeneratorForm[data-tab="learn"] #roleLegend,
+        #bassGeneratorForm[data-tab="learn"] #romanRow { display: none !important; }
+        #bassGeneratorForm[data-tab="learn"] .paper {
+            max-height: 148px; overflow-y: auto; padding: 4px 6px; margin: 0;
+        }
+        /* 악보 자체를 축소 렌더 (커서는 렌더 폭 기준으로 자동 보정됨) */
+        #bassGeneratorForm[data-tab="learn"] #vexflowScore svg {
+            width: 66% !important; height: auto !important;
+        }
+        #bassGeneratorForm[data-tab="learn"] #sheetMusicCanvas {
+            width: 66% !important; height: auto !important;
+        }
+        /* 슬림 트랜스포트: 작은 재생 버튼 + 소형 토글 */
+        #bassGeneratorForm[data-tab="learn"] .bl-transport {
+            margin-top: 8px; padding: 6px 10px; gap: 10px; border-radius: 12px;
+        }
+        #bassGeneratorForm[data-tab="learn"] .bl-play {
+            width: 38px; height: 38px; font-size: 0.95rem;
+        }
+        #bassGeneratorForm[data-tab="learn"] .bl-play::after { inset: -3px; }
+        #bassGeneratorForm[data-tab="learn"] .bl-toggles { gap: 6px; }
+        #bassGeneratorForm[data-tab="learn"] .bl-toggle {
+            padding: 4px 10px; font-size: 0.74rem;
+        }
+        #bassGeneratorForm[data-tab="learn"] #transportStatus {
+            font-size: 0.72rem; padding: 2px 6px;
+        }
 
         /* 히스토리: 세로 무한 증가 → 반응형 그리드 + 높이 제한 스크롤 */
         .bl-history-list {
@@ -3382,6 +3412,16 @@
                         cursor.style.left = ((sRect.left - stRect.left) + xN * scale) + 'px';
                         cursor.style.top = ((sRect.top - stRect.top) + seg.top * scale) + 'px';
                         cursor.style.height = (seg.h * scale) + 'px';
+
+                        // 악보 종이가 세로 스크롤 상태(학습 탭 컴팩트 뷰)면 커서 줄을 자동 추적
+                        const paper = document.getElementById('notation-area');
+                        if (paper && paper.scrollHeight > paper.clientHeight + 4) {
+                            const cy = stage.offsetTop + (parseFloat(cursor.style.top) || 0);
+                            const chH = parseFloat(cursor.style.height) || 40;
+                            if (cy < paper.scrollTop + 2 || cy + chH > paper.scrollTop + paper.clientHeight - 2) {
+                                paper.scrollTop = Math.max(0, cy - 6);
+                            }
+                        }
                     }
                 }
                 __cursorRAF = requestAnimationFrame(frame);


### PR DESCRIPTION
## 변경
학습 탭에서 상단 고정된 악보/재생 영역이 화면을 너무 차지해 학습 공간이 좁고 스크롤이 불편하던 문제 — **761px → 230px (70% 축소)**.

- 학습 탭에서 스테이지 헤더("생성된 악보"+칩)·역할 범례·로마숫자 행 숨김 (스튜디오 탭은 그대로)
- **악보 66% 축소 렌더** + 종이 높이 148px 제한(내부 스크롤)
- 재생 버튼 62→38px, 토글·상태 칩 소형화, 패딩 슬림화
- 스테이지 자체 overflow 스크롤 제거 → **중첩 스크롤의 어색함 해소**
- **커서 자동 추적 스크롤**: 재생 커서가 접힌 둘째 줄로 넘어가면 악보 종이가 자동으로 따라 스크롤
- 축소 상태에서도 커서 좌표는 렌더 폭 기준으로 자동 보정되어 정확히 음표 위를 따라감 (검증됨)

## ✅ 검증 (Playwright)
- 스테이지 높이 761px → 230px 측정
- 축소 SVG(66%) 위에서 커서 이동·범위 내 유지 확인
- 스튜디오 탭 복귀 시 원래 크기/구성 복원, 유닛 50개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5jACdksKje2ZhNtNuAAUX)_