### PR TITLE
학습 탭에서 '분석 보기' 토글·역할 범례 노출

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -698,9 +698,17 @@
         [data-theme="dark"] #bassGeneratorForm[data-tab="learn"] .bl-stage {
             box-shadow: 0 8px 22px rgba(0, 0, 0, 0.6);
         }
-        #bassGeneratorForm[data-tab="learn"] .bl-stage__head,
-        #bassGeneratorForm[data-tab="learn"] #roleLegend,
-        #bassGeneratorForm[data-tab="learn"] #romanRow { display: none !important; }
+        /* 학습 탭 헤더: 제목·정적 칩은 숨기고 '분석 보기' 토글만 컴팩트하게 남긴다.
+           분석(음표 역할 색칠·범례·로마숫자)은 학습의 핵심이라 학습 탭에서도 보이게 한다. */
+        #bassGeneratorForm[data-tab="learn"] .bl-stage__head {
+            margin: 0 0 4px; gap: 6px;
+        }
+        #bassGeneratorForm[data-tab="learn"] .bl-stage__title,
+        #bassGeneratorForm[data-tab="learn"] .bl-stage__chips .bl-chip { display: none !important; }
+        #bassGeneratorForm[data-tab="learn"] #learnToggle { padding: 3px 9px; font-size: 0.7rem; }
+        #bassGeneratorForm[data-tab="learn"] #roleLegend { margin: 4px 0 0; gap: 4px 9px; font-size: 0.66rem; }
+        #bassGeneratorForm[data-tab="learn"] #roleLegend .role-chip i { width: 8px; height: 8px; }
+        #bassGeneratorForm[data-tab="learn"] #romanRow { margin: 0 0 3px; font-size: 0.66rem; }
         #bassGeneratorForm[data-tab="learn"] .paper {
             /* 고정 높이 — 데모마다 악보 줄 수가 달라도 스테이지 높이가 변하지 않아
                스크롤 앵커링에 의한 페이지 위치 흔들림이 없다. */


### PR DESCRIPTION
## Summary
학습 탭에서 `.bl-stage__head` 전체가 `display:none`으로 숨겨져 **'🔍 분석 보기' 토글이 사라지고**, 역할 범례(`#roleLegend`)·로마숫자(`#romanRow`)도 `!important`로 강제 숨김되어 분석 색칠의 의미를 볼 수 없던 문제를 수정.

- 학습 탭에서 헤더의 **제목·정적 칩만 숨기고** '분석 보기' 토글은 컴팩트하게 남김
- 음표 역할 색칠·범례·로마숫자는 학습의 핵심이므로 학습 탭에서도 표시(분석 ON일 때)
- 토글 on/off에 범례가 그대로 따라감

## Test plan
- [x] Playwright(학습 탭): `#learnToggle` 노출 확인, 제목/클레프 칩 숨김 확인
- [x] Playwright: 분석 토글 OFF→범례 숨김·버튼 비활성, ON→범례 표시·버튼 활성
- [x] 스크린샷으로 컴팩트 레이아웃 확인(토글 상단, 범례 악보 아래, 슬림 트랜스포트 유지)
- [x] 페이지 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5jACdksKje2ZhNtNuAAUX)_