### PR TITLE
악보 없이 소리만 나는 데모/퀴즈를 리얼 베이스로 재생

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2517,14 +2517,61 @@
             }
             return __quizSynth;
         }
-        async function playIntervalDemo(semis) {
+
+        // ── 즉시 재생용 리얼 베이스(악보 없이 소리만 나는 데모/퀴즈용) ──
+        // 메인 트랜스포트와 충돌하지 않도록 전용 샘플러 인스턴스를 쓴다(샘플은 브라우저 캐시 재사용).
+        // 톤은 또렷하게 들리도록 항상 '핑거'로 고정(뮤트 프리셋이면 안 들리는 문제 회피).
+        let __demoBass = null, __demoBassLoading = null;
+        function getDemoBass() {
+            if (__demoBass) return Promise.resolve(__demoBass);
+            if (__demoBassLoading) return __demoBassLoading;
+            __demoBassLoading = new Promise((resolve) => {
+                let done = false;
+                const finish = (v) => { if (!done) { done = true; resolve(v); } };
+                let smp;
+                try {
+                    smp = new Tone.Sampler({
+                        urls: BASS_SAMPLE_URLS, baseUrl: BASS_SAMPLE_BASE, release: 0.4,
+                        onload: () => {
+                            const lim = new Tone.Limiter(-1).toDestination();
+                            const out = new Tone.Gain(1.15).connect(lim);      // 데모는 확실히 들리게(리미터가 클리핑 방지)
+                            const bus = makeBassBus(out, BASS_TONES.finger);   // 또렷한 핑거 톤 고정
+                            smp.connect(bus.input);
+                            __demoBass = { sampler: smp, vfilt: bus.vfilt };
+                            finish(__demoBass);
+                        },
+                        onerror: () => finish(null),
+                    });
+                } catch (e) { finish(null); return; }
+                setTimeout(() => { if (!__demoBass) finish(null); }, 9000);
+            }).then(v => { __demoBassLoading = null; return v; });
+            return __demoBassLoading;
+        }
+        // events: [{note, dur, at(초 오프셋), vel}] — 리얼 베이스로 즉시 재생(실패 시 합성음 폴백)
+        async function playDemoNotes(events) {
             if (typeof Tone === 'undefined') return;
             await Tone.start();
-            const synth = ensureQuizSynth();
-            const target = Tone.Frequency('C2').transpose(semis).toNote();
+            const db = await getDemoBass();
             const now = Tone.now();
-            synth.triggerAttackRelease('C2', 0.55, now, 0.9);
-            synth.triggerAttackRelease(target, 0.75, now + 0.7, 0.9);
+            if (db) {
+                events.forEach(e => {
+                    const vel = e.vel ?? 0.95;
+                    db.vfilt.frequency.setValueAtTime(velToCutoff(vel, BASS_TONES.finger), now + e.at);
+                    db.sampler.triggerAttackRelease(e.note, e.dur, now + e.at, vel);
+                });
+            } else {
+                const synth = ensureQuizSynth();
+                events.forEach(e => synth.triggerAttackRelease(e.note, e.dur, now + e.at, e.vel ?? 0.9));
+            }
+        }
+
+        async function playIntervalDemo(semis) {
+            if (typeof Tone === 'undefined') return;
+            const target = Tone.Frequency('C2').transpose(semis).toNote();
+            await playDemoNotes([
+                { note: 'C2', dur: 0.6, at: 0, vel: 0.95 },
+                { note: target, dur: 0.85, at: 0.7, vel: 0.95 },
+            ]);
             showMessage('🎧 C2 → ' + target + ' (' + semis + '반음)', 'info');
         }
         async function demoProgressionRun(d) {
@@ -2822,12 +2869,11 @@
         }
         async function playQuizSound() {
             if (typeof Tone === 'undefined' || !__quiz) return;
-            await Tone.start();
-            const synth = ensureQuizSynth();
             const target = Tone.Frequency(__quiz.root).transpose(__quiz.answer.s).toNote();
-            const now = Tone.now();
-            synth.triggerAttackRelease(__quiz.root, 0.55, now, 0.9);
-            synth.triggerAttackRelease(target, 0.7, now + 0.75, 0.9);
+            await playDemoNotes([
+                { note: __quiz.root, dur: 0.6, at: 0, vel: 0.95 },
+                { note: target, dur: 0.8, at: 0.75, vel: 0.95 },
+            ]);
         }
         function answerQuiz(semis) {
             if (!__quiz || __quiz.answered != null) return;


### PR DESCRIPTION
## Summary
음정 듣기(반음/온음 듣기)와 귀 훈련 퀴즈(🔊 문제 듣기)는 악보를 띄우지 않고 소리만 즉시 재생하는데, 그동안 **최후 폴백용 얇은 합성음**(`makeBassSynth`)을 써서 "잘 안 들리는" 문제가 있었습니다. 이제 로컬 리얼 베이스 샘플로 재생합니다.

- 전용 데모 샘플러(`getDemoBass`) + `playDemoNotes` 헬퍼 추가 — 메인 트랜스포트와 독립된 인스턴스(샘플은 브라우저 캐시 재사용)
- 앰프 톤 버스 경유, 톤은 **'핑거' 고정**(뮤트 프리셋이어도 또렷하게 들림)
- 벨로시티 그로울 반영, 게인 1.15로 확실히 들리게(리미터가 클리핑 방지)
- 샘플 로드 실패 시 기존 합성음으로 안전 폴백

`circle5Pick`·`diatonicPlay` 등 악보를 띄우는 데모는 이미 메인 엔진(리얼 베이스)을 쓰므로 변경 없음.

## Test plan
- [x] Playwright: interval 데모·퀴즈 4음 모두 데모 샘플러로 트리거(합성 폴백 미사용)
- [x] Playwright: 데모 샘플 전부 로컬 로드(`/static/bass_samples/*`), 외부 요청 0
- [x] Playwright: 게인 1.15에서 피크 0.622·RMS 0.190(기존 합성음 대비 큼), 클리핑 없음(리미터)
- [x] 페이지 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5jACdksKje2ZhNtNuAAUX)_